### PR TITLE
Emitters now emit stream of tokens rather than a string.

### DIFF
--- a/src/IR/toplevel.ts
+++ b/src/IR/toplevel.ts
@@ -39,7 +39,7 @@ export interface VarDeclaration extends BaseExpr {
 }
 
 export function block(children: Statement[]): Block {
-  return { type: "Block", children, requiresBlock: children.length > 1 };
+  return { type: "Block", children, requiresBlock: false };
 }
 
 export function ifStatement(

--- a/src/IR/toplevel.ts
+++ b/src/IR/toplevel.ts
@@ -14,6 +14,7 @@ export interface Variants {
 export interface Block {
   type: "Block";
   children: Statement[];
+  requiresBlock: boolean;
 }
 
 /**
@@ -38,7 +39,7 @@ export interface VarDeclaration extends BaseExpr {
 }
 
 export function block(children: Statement[]): Block {
-  return { type: "Block", children };
+  return { type: "Block", children, requiresBlock: children.length > 1 };
 }
 
 export function ifStatement(

--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -39,12 +39,7 @@ export const defaultIdentGen = {
 };
 
 function isAlphaNum(a: string, i: number): boolean {
-  const code = a.charCodeAt(i);
-  return (
-    (code > 47 && code < 58) || // numeric (0-9)
-    (code > 64 && code < 91) || // upper alpha (A-Z)
-    (code > 96 && code < 123)
-  ); // lower alpha (a-z)
+  return /[A-Za-z0-9]/.test(a[i]);
 }
 
 export function defaultWhitespaceInsertLogic(a: string, b: string): boolean {

--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -55,10 +55,21 @@ export function defaultDetokenizer(
   whitespace: WhitespaceInsertLogic = defaultWhitespaceInsertLogic
 ): Detokenizer {
   return function (tokens: string[]): string {
+    let indentLevel = 0;
     let result = tokens[0];
     for (let i = 1; i < tokens.length; i++) {
-      if (whitespace(tokens[i - 1], tokens[i])) result += " ";
-      result += tokens[i];
+      if (tokens[i] === "$INDENT$") indentLevel++;
+      else if (tokens[i] === "$DEDENT$") indentLevel--;
+      else {
+        if (
+          tokens[i - 1] !== "$INDENT$" &&
+          tokens[i - 1] !== "$DEDENT$" &&
+          whitespace(tokens[i - 1], tokens[i])
+        )
+          result += " ";
+        result +=
+          tokens[i] + (tokens[i] === "\n" ? " ".repeat(indentLevel) : "");
+      }
     }
     return result;
   };

--- a/src/common/applyLanguage.ts
+++ b/src/common/applyLanguage.ts
@@ -1,7 +1,13 @@
 import { Expr, IR, Program } from "../IR";
 import { expandVariants } from "./expandVariants";
 import { programToPath, Path } from "./traverse";
-import { Language, IdentifierGenerator, OpTransformOutput } from "./Language";
+import {
+  Language,
+  IdentifierGenerator,
+  OpTransformOutput,
+  defaultDetokenizer,
+  defaultIdentGen,
+} from "./Language";
 import { getType } from "./getType";
 
 function applyLanguageToVariant(
@@ -18,12 +24,14 @@ function applyLanguageToVariant(
   if (language.dependencyMap !== undefined) {
     addDependencies(path, language.dependencyMap);
   }
-  const identMap = getIdentMap(path, language.identGen);
+  const identMap = getIdentMap(path, language.identGen ?? defaultIdentGen);
   if (language.opMap !== undefined) {
     path.visit(mapOps(language.opMap, program));
   }
   path.visit(nameIdents(identMap));
-  return language.emitter(program);
+  return (language.detokenizer ?? defaultDetokenizer())(
+    language.emitter(program)
+  );
 }
 
 function addDependencies(

--- a/src/languages/lua/index.ts
+++ b/src/languages/lua/index.ts
@@ -1,9 +1,5 @@
 import { functionCall, methodCall } from "../../IR";
-import {
-  Language,
-  defaultIdentGen,
-  OpTransformOutput,
-} from "../../common/Language";
+import { Language, OpTransformOutput } from "../../common/Language";
 import { removeMutatingBinaryOp } from "../../plugins/mutatingBinaryOps";
 import { oneIndexed } from "../../plugins/oneIndexed";
 import { forRangeToForRangeInclusive } from "../../plugins/loops";
@@ -14,11 +10,10 @@ const luaLanguage: Language = {
   name: "Lua",
   plugins: [removeMutatingBinaryOp, forRangeToForRangeInclusive, oneIndexed],
   emitter: emitProgram,
-  identGen: defaultIdentGen,
   opMap: new Map<string, OpTransformOutput>([
     ["str_length", (x, _) => methodCall("str_length", x, [], "len")],
     ["int_to_str", (x, _) => functionCall("int_to_str", [x], "tostring")],
-    ["repeat", (x, y) => functionCall("repeat", [x, y], "string.rep")],
+    ["repeat", (x, y) => methodCall("repeat", x, [y], "rep")],
     ["add", "+"],
     ["sub", "-"],
     ["mul", "*"],

--- a/src/plugins/blocks.ts
+++ b/src/plugins/blocks.ts
@@ -1,0 +1,30 @@
+import { Path, Visitor } from "../common/traverse";
+import { IR } from "../IR";
+
+export function requireBlockWhen(nodeTypes: string[] = []): Visitor {
+  return {
+    exit(path: Path) {
+      const node = path.node;
+      if (node.type === "Block") {
+        node.requiresBlock = hasBlockRequiringChild(path, nodeTypes);
+      }
+    },
+  };
+}
+
+function hasBlockRequiringChild(
+  path: Path<IR.Node>,
+  nodeTypes: string[]
+): boolean {
+  for (const childPath of path.getChildPaths()) {
+    const node = childPath.node;
+    if (
+      (nodeTypes.includes("blocks") &&
+        ("consequent" in node || "children" in node)) ||
+      nodeTypes.includes(node.type)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/plugins/blocks.ts
+++ b/src/plugins/blocks.ts
@@ -28,3 +28,12 @@ function hasBlockRequiringChild(
   }
   return false;
 }
+
+export const requireBlockWhenMultiple: Visitor = {
+  exit(path: Path) {
+    const node = path.node;
+    if (node.type === "Block") {
+      node.requiresBlock = node.children.length > 1;
+    }
+  },
+};

--- a/src/plugins/loops.ts
+++ b/src/plugins/loops.ts
@@ -1,4 +1,4 @@
-import { getType } from "common/getType";
+import { getType } from "../common/getType";
 import { Path } from "../common/traverse";
 import {
   forRange,


### PR DESCRIPTION
The final conversion to string is handled by the `detokenizer` field of `Language`. There's a default dekonizer which joins the tokens, adding spaces in between when neccessary (= by default when two alphanum characters would be next to each other) and appends the indentation (using spaces) to each `\n`. It expects tokens valued `$INDENT$` and `$DEDENT$` to signal the change of indentation.

Also adds `requiresBlock` field to `Block` which by default behaves like in C - curly braces are required if there's more that one children. There's a plugin which changes this flag to how it works in Python - indentation is required if one of the children is a block. Emitter of block should consult this flag in order to emit the block properly - some languages (Lua) can just ignore it.