### PR TITLE
Allow plugins to generate variants

### DIFF
--- a/src/common/applyLanguage.ts
+++ b/src/common/applyLanguage.ts
@@ -14,11 +14,11 @@ export function applyLanguage(
     expandVariants(program),
     maxBranches
   );
-  const variantsPluginsIndeces = [...language.plugins.keys()].filter(
+  const variantsPluginsIndices = [...language.plugins.keys()].filter(
     (i) => language.plugins[i].generatesVariants === true
   );
   let lastAppliedPluginIndex = -1;
-  for (const vpi of variantsPluginsIndeces) {
+  for (const vpi of variantsPluginsIndices) {
     for (let i = lastAppliedPluginIndex + 1; i < vpi; i++) {
       emittedVariants.forEach((v) => {
         const path = programToPath(v[0]);

--- a/src/common/applyLanguage.ts
+++ b/src/common/applyLanguage.ts
@@ -3,56 +3,63 @@ import { expandVariants } from "./expandVariants";
 import { programToPath } from "./traverse";
 import { Language, defaultDetokenizer } from "./Language";
 
-export function applyLanguageToVariant(
+export function applyLanguage(
   language: Language,
-  program: IR.Program
+  program: IR.Program,
+  maxBranches: number = 1000
 ): string {
-  const path = programToPath(program);
-  // Apply each visitor sequentially, re-walking the tree for each one
-  // A different option is to merge visitors together (like Babel) to apply
-  // them simultaneously, but be careful to go in order between the plugins
-  for (const visitor of language.plugins) {
-    path.visit(visitor);
-  }
-  return (language.detokenizer ?? defaultDetokenizer())(
-    language.emitter(program)
+  let emittedVariants: [IR.Program, string][] = emitVariants(
+    language,
+    -1,
+    expandVariants(program),
+    maxBranches
   );
-}
-
-export function applyLanguageToVariants(
-  language: Language,
-  programs: IR.Program[]
-): string {
-  if (programs.length === 1) {
-    return applyLanguageToVariant(language, programs[0]);
-  }
-  let result: string | null = null;
-  const errors = new Map<string, number>();
-  let mostCommonErrorCount = 0;
-  let mostCommonError = "";
-  programs.forEach((x) => {
-    try {
-      const compiled = applyLanguageToVariant(language, x);
-      if (result === null || result.length > compiled.length) {
-        result = compiled;
-      }
-    } catch (err) {
-      if (err instanceof Error) {
-        errors.set(err.message, (errors.get(err.message) ?? 0) + 1);
-        if (errors.get(err.message)! > mostCommonErrorCount) {
-          mostCommonErrorCount++;
-          mostCommonError = err.message;
-        }
+  const variantsPluginsIndeces = [...language.plugins.keys()].filter(
+    (i) => language.plugins[i].generatesVariants
+  );
+  let lastAppliedPluginIndex = -1;
+  for (const vpi of variantsPluginsIndeces) {
+    for (let i = lastAppliedPluginIndex + 1; i < vpi; i++) {
+      emittedVariants.forEach((v) => {
+        const path = programToPath(v[0]);
+        path.visit(language.plugins[i]);
+      });
+    }
+    const newVariants: IR.Program[] = [];
+    for (const variant of emittedVariants) {
+      const path = programToPath(variant[0]);
+      path.visit(language.plugins[vpi]);
+      for (const newVariant of expandVariants(variant[0])) {
+        newVariants.push(newVariant);
       }
     }
-  });
-  if (result !== null) return result;
-  throw new Error(
-    "No variant could be compiled. Most common error follows. " +
-      mostCommonError
-  );
+    lastAppliedPluginIndex = vpi;
+    emittedVariants = emitVariants(language, vpi, newVariants, maxBranches);
+  }
+  return emittedVariants[0][1];
 }
 
-export function applyLanguage(language: Language, program: IR.Program): string {
-  return applyLanguageToVariants(language, expandVariants(program));
+function emitVariants(
+  language: Language,
+  lastAppliedPluginIndex: number,
+  variants: IR.Program[],
+  maxBranches: number
+): [IR.Program, string][] {
+  const result: [IR.Program, string][] = [];
+  for (const variant of variants) {
+    const path = programToPath(variant);
+    for (let i = lastAppliedPluginIndex + 1; i < language.plugins.length; i++) {
+      path.visit(language.plugins[i]);
+    }
+    try {
+      result.push([
+        variant,
+        (language.detokenizer ?? defaultDetokenizer())(
+          language.emitter(variant)
+        ),
+      ]);
+    } catch {}
+  }
+  result.sort((a, b) => a[1].length - b[1].length);
+  return result.slice(0, maxBranches);
 }

--- a/src/common/applyLanguage.ts
+++ b/src/common/applyLanguage.ts
@@ -15,7 +15,7 @@ export function applyLanguage(
     maxBranches
   );
   const variantsPluginsIndeces = [...language.plugins.keys()].filter(
-    (i) => language.plugins[i].generatesVariants
+    (i) => language.plugins[i].generatesVariants === true
   );
   let lastAppliedPluginIndex = -1;
   for (const vpi of variantsPluginsIndeces) {
@@ -49,6 +49,7 @@ function emitVariants(
   for (const variant of variants) {
     const path = programToPath(variant);
     for (let i = lastAppliedPluginIndex + 1; i < language.plugins.length; i++) {
+      if (language.plugins[i].generatesVariants === true) continue;
       path.visit(language.plugins[i]);
     }
     try {

--- a/src/common/traverse.ts
+++ b/src/common/traverse.ts
@@ -224,4 +224,5 @@ export function programToPath(node: IR.Program) {
 export interface Visitor {
   enter?: (path: Path) => void;
   exit?: (path: Path) => void;
+  generatesVariants?: boolean;
 }


### PR DESCRIPTION
A simple way of allowing plugins to create variants, until we decide to implement something more sophisticated.

Plugins can now create `Variant` nodes. If they do, they must set their `.generatesVariants: true` flag.

Plugins are applied one by one as before, but when a variant generating plugin is executed, the variants are expanded, sorted by emitted length (for this purpose all remaining non-variant-emitting plugins are run) and only the so far shortest are kept.