### PR TITLE
Polygolf emit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import lua from "./languages/lua";
 import nim from "./languages/nim";
 import polygolf from "./languages/polygolf";
 
-const languageTable = { lua, nim, polygolf: polygolf(true, true) };
+const languageTable = { lua, nim, polygolf: polygolf(true, false) };
 
 const options = yargs()
   .options({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import lua from "./languages/lua";
 import nim from "./languages/nim";
 import polygolf from "./languages/polygolf";
 
-const languageTable = { lua, nim, polygolf: polygolf(true, false) };
+const languageTable = { lua, nim, polygolf: polygolf(true) };
 
 const options = yargs()
   .options({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,12 +5,13 @@ import fs from "fs";
 import path from "path";
 import parse from "./frontend/parse";
 import applyLanguage from "./common/applyLanguage";
+import { PolygolfError } from "./common/errors";
 
 import lua from "./languages/lua";
 import nim from "./languages/nim";
-import { PolygolfError } from "./common/errors";
+import polygolf from "./languages/polygolf";
 
-const languageTable = { lua, nim };
+const languageTable = { lua, nim, polygolf: polygolf(true, true) };
 
 const options = yargs()
   .options({

--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -34,7 +34,8 @@ export function defaultWhitespaceInsertLogic(a: string, b: string): boolean {
 }
 
 export function defaultDetokenizer(
-  whitespace: WhitespaceInsertLogic = defaultWhitespaceInsertLogic
+  whitespace: WhitespaceInsertLogic = defaultWhitespaceInsertLogic,
+  indent = 1
 ): Detokenizer {
   return function (tokens: string[]): string {
     let indentLevel = 0;
@@ -50,7 +51,8 @@ export function defaultDetokenizer(
         )
           result += " ";
         result +=
-          tokens[i] + (tokens[i] === "\n" ? " ".repeat(indentLevel) : "");
+          tokens[i] +
+          (tokens[i] === "\n" ? " ".repeat(indentLevel * indent) : "");
       }
     }
     return result.trim();

--- a/src/common/applyLanguage.ts
+++ b/src/common/applyLanguage.ts
@@ -9,7 +9,8 @@ export default function applyLanguage(
   maxBranches: number = 1000,
   skipTypesPass: boolean = false
 ): string {
-  const variants = expandVariants(program);
+  const variants =
+    language.name === "Polygolf" ? [program] : expandVariants(program);
   if (!skipTypesPass) {
     for (const variant of variants) {
       typesPass(variant);

--- a/src/common/debug.ts
+++ b/src/common/debug.ts
@@ -1,0 +1,13 @@
+import { Program } from "../IR";
+import polygolfLanguage from "../languages/polygolf";
+import applyLanguage from "./applyLanguage";
+
+export default function debug(
+  program: Program,
+  stripTypes = false,
+  skipTypesPass = true
+) {
+  console.log(
+    applyLanguage(polygolfLanguage(stripTypes), program, 1, skipTypesPass)
+  );
+}

--- a/src/common/getType.ts
+++ b/src/common/getType.ts
@@ -43,6 +43,8 @@ export function calcType(expr: Expr, program: Program): ValueType {
     case "Block":
     case "VarDeclaration":
       return voidType;
+    case "Variants":
+      return expr.variants.map(type).reduce(union);
     case "Assignment": {
       const a = type(expr.variable);
       const b = type(expr.expr);

--- a/src/languages/polygolf/emit.ts
+++ b/src/languages/polygolf/emit.ts
@@ -1,5 +1,5 @@
 import { joinGroups } from "../../common/emit";
-import { block, Expr, IR, toString, Variants } from "../../IR";
+import { block, Expr, IR, toString, variants, Variants } from "../../IR";
 
 export default function emitProgram(program: IR.Program): string[] {
   return emitExpr(program.body, true);
@@ -170,9 +170,13 @@ function emitExpr(expr: Expr, asStatement = false, indent = false): string[] {
     case "ConditionalOp":
       return emitSexpr("@", expr.condition, expr.consequent, expr.alternate);
     case "ManyToManyAssignment":
-      return emitSexpr("@", block(expr.variables), block(expr.exprs));
+      return emitSexpr(
+        "@",
+        variants([block(expr.variables)]),
+        variants([block(expr.exprs)])
+      );
     case "OneToManyAssignment":
-      return emitSexpr("@", block(expr.variables), expr.expr);
+      return emitSexpr("@", variants([block(expr.variables)]), expr.expr);
     case "ImportStatement":
       return emitSexpr(
         "@",

--- a/src/languages/polygolf/emit.ts
+++ b/src/languages/polygolf/emit.ts
@@ -1,0 +1,5 @@
+import { IR } from "../../IR";
+
+export default function emitProgram(program: IR.Program): string[] {
+  return ["TODO"];
+}

--- a/src/languages/polygolf/emit.ts
+++ b/src/languages/polygolf/emit.ts
@@ -1,5 +1,207 @@
-import { IR } from "../../IR";
+import { joinGroups } from "../../common/emit";
+import { block, Expr, IR, toString } from "../../IR";
 
 export default function emitProgram(program: IR.Program): string[] {
-  return ["TODO"];
+  return emitExpr(program.body, true);
+}
+
+function emitExpr(expr: Expr, asStatement = false): string[] {
+  function emitSexpr(op: string, ...args: (string | Expr)[]): string[] {
+    if (op === "@") op += expr.type;
+    if (asStatement) {
+      return [
+        op,
+        ...joinGroups(
+          args.map((x) => (typeof x === "string" ? [x] : emitExpr(x)))
+        ),
+        ";",
+      ];
+    }
+    return [
+      "(",
+      op,
+      ...joinGroups(
+        args.map((x) => (typeof x === "string" ? [x] : emitExpr(x)))
+      ),
+      ")",
+      ...(expr.valueType === undefined ? [] : [":", toString(expr.valueType)]),
+    ];
+  }
+  switch (expr.type) {
+    case "Block":
+      return [
+        ...joinGroups(
+          expr.children.map((x) => emitExpr(x, true)),
+          "\n"
+        ),
+      ];
+    case "Variants":
+      return [
+        "{",
+        ...joinGroups(
+          expr.variants.map((x) => emitExpr(x, true)),
+          "/"
+        ),
+        "}",
+      ];
+    case "KeyValue":
+      return emitSexpr("key_value", expr.key, expr.value);
+    case "PolygolfOp":
+      return emitSexpr(expr.op, ...expr.args);
+    case "VarDeclaration":
+      return emitSexpr("@", expr.variable, toString(expr.variableType));
+    case "VarDeclarationWithAssignment":
+      return emitSexpr(
+        "@",
+        expr.assignments,
+        "{" + (expr.valueTypes ?? []).map(toString).join(" ") + "}"
+      );
+    case "Assignment":
+      return emitSexpr("assign", expr.variable, expr.expr);
+    case "IndexCall":
+      return emitSexpr(
+        "@",
+        String(expr.oneIndexed),
+        expr.op ?? "?",
+        expr.collection,
+        expr.index
+      );
+    case "RangeIndexCall":
+      return emitSexpr(
+        "@",
+        String(expr.oneIndexed),
+        expr.op ?? "?",
+        expr.collection,
+        expr.low,
+        expr.high,
+        expr.step
+      );
+    case "FunctionCall":
+      return emitSexpr(
+        "@",
+        expr.op ?? "?",
+        ...emitExpr(expr.ident),
+        ...expr.args
+      );
+    case "MethodCall":
+      return emitSexpr(
+        "@",
+        expr.op ?? "?",
+        ...emitExpr(expr.ident),
+        expr.object,
+        ...expr.args
+      );
+    case "BinaryOp":
+      return emitSexpr(
+        "@",
+        expr.op,
+        String(expr.precedence),
+        String(expr.rightAssociative),
+        expr.name,
+        expr.left,
+        expr.right
+      );
+    case "UnaryOp":
+      return emitSexpr(
+        "@",
+        expr.op,
+        String(expr.precedence),
+        expr.name,
+        expr.arg
+      );
+    case "Identifier":
+      if (expr.builtin) {
+        return emitSexpr("@BuiltinIdent", JSON.stringify(expr.name));
+      } else {
+        return ["$" + expr.name];
+      }
+    case "StringLiteral":
+      return [JSON.stringify(expr.value)];
+    case "IntegerLiteral":
+      return [expr.value.toString()];
+    case "ArrayConstructor":
+      return emitSexpr("array", ...expr.exprs);
+    case "ListConstructor":
+      return emitSexpr("list", ...expr.exprs);
+    case "SetConstructor":
+      return emitSexpr("set", ...expr.exprs);
+    case "TableConstructor":
+      return emitSexpr("table", ...expr.kvPairs);
+    case "MutatingBinaryOp":
+      return emitSexpr("@", expr.op, expr.name, expr.variable, expr.right);
+    case "ConditionalOp":
+      return emitSexpr("@", expr.condition, expr.consequent, expr.alternate);
+    case "ManyToManyAssignment":
+      return emitSexpr("@", block(expr.variables), block(expr.exprs));
+    case "OneToManyAssignment":
+      return emitSexpr("@", block(expr.variables), expr.expr);
+    case "ImportStatement":
+      return emitSexpr(
+        "@",
+        ...[expr.name, ...expr.modules].map((x) => JSON.stringify(x))
+      );
+    case "WhileLoop":
+      return emitSexpr(
+        "while",
+        expr.condition,
+        "$INDENT$",
+        "\n",
+        expr.body,
+        "$DEDENT$"
+      );
+    case "ForRange":
+      if (expr.inclusive) {
+        return emitSexpr(
+          "@ForRangeInclusive",
+          expr.variable,
+          expr.low,
+          expr.high,
+          expr.increment,
+          "$INDENT$",
+          "\n",
+          expr.body,
+          "$DEDENT$"
+        );
+      }
+      return emitSexpr(
+        "for",
+        expr.variable,
+        expr.low,
+        expr.high,
+        ...(expr.increment.type === "IntegerLiteral" &&
+        expr.increment.value === 1n
+          ? []
+          : [expr.increment]),
+        "$INDENT$",
+        "\n",
+        expr.body,
+        "$DEDENT$"
+      );
+    case "ForEach":
+      return emitSexpr("@", expr.variable, expr.collection, expr.body);
+    case "ForEachKey":
+      return emitSexpr("@", expr.variable, expr.table, expr.body);
+    case "ForEachPair":
+      return emitSexpr(
+        "@",
+        expr.keyVariable,
+        expr.valueVariable,
+        expr.table,
+        expr.body
+      );
+    case "ForCLike":
+      return emitSexpr("@", expr.init, expr.condition, expr.append, expr.body);
+    case "IfStatement":
+      return emitSexpr(
+        "if",
+        expr.condition,
+        "$INDENT$",
+        "\n",
+        expr.consequent,
+        "$DEDENT$",
+        ...(expr.alternate === undefined
+          ? []
+          : ["$INDENT$", "\n", expr.alternate, "$DEDENT$"])
+      );
+  }
 }

--- a/src/languages/polygolf/emit.ts
+++ b/src/languages/polygolf/emit.ts
@@ -146,7 +146,12 @@ function emitExpr(expr: Expr, asStatement = false, indent = false): string[] {
       if (expr.builtin) {
         return emitSexpr("@BuiltinIdent", JSON.stringify(expr.name));
       } else {
-        return ["$" + expr.name];
+        return [
+          "$" + expr.name,
+          ...(expr.valueType === undefined
+            ? []
+            : [":", toString(expr.valueType)]),
+        ];
       }
     case "StringLiteral":
       return [JSON.stringify(expr.value)];

--- a/src/languages/polygolf/emit.ts
+++ b/src/languages/polygolf/emit.ts
@@ -6,14 +6,18 @@ export default function emitProgram(program: IR.Program): string[] {
 }
 
 function emitVariants(expr: Variants, indent = false): string[] {
-  if (indent) {
+  if (indent || expr.variants.some((x) => x.type === "Block")) {
     return [
       "{",
       "$INDENT$",
       "\n",
       ...joinGroups(
         expr.variants.map((x) => emitExpr(x, true)),
-        "/"
+        "$DEDENT$",
+        "\n",
+        "/",
+        "$INDENT$",
+        "\n"
       ),
       "$DEDENT$",
       "\n",

--- a/src/languages/polygolf/index.ts
+++ b/src/languages/polygolf/index.ts
@@ -15,7 +15,15 @@ function polygolfLanguage(stripTypes = false, forceBlocks = true): Language {
     emitter: emitProgram,
     plugins,
     detokenizer: defaultDetokenizer(
-      (a, b) => a !== "(" && b !== ")" && b !== ";" && b !== ":" && a !== ":"
+      (a, b) =>
+        a !== "(" &&
+        b !== ")" &&
+        b !== ";" &&
+        b !== ":" &&
+        a !== ":" &&
+        a !== "\n" &&
+        b !== "\n",
+      2
     ),
   };
 }
@@ -82,7 +90,8 @@ const blocksAsVariants: Visitor = {
     if (
       node.type === "Block" &&
       path.parent !== null &&
-      path.parent.node.type !== "Variants"
+      path.parent.node.type !== "Variants" &&
+      path.parent.node.type !== "Program"
     ) {
       path.replaceWith(variants([node]));
     }

--- a/src/languages/polygolf/index.ts
+++ b/src/languages/polygolf/index.ts
@@ -5,9 +5,8 @@ import emitProgram from "./emit";
 import { Path, Visitor } from "../../common/traverse";
 import { calcType, getType } from "../../common/getType";
 
-function polygolfLanguage(stripTypes = false, forceBlocks = true): Language {
+function polygolfLanguage(stripTypes = false): Language {
   const plugins: Visitor[] = [];
-  if (forceBlocks) plugins.push(forceControlFlowBlocks);
   plugins.push(blocksAsVariants);
   if (stripTypes) plugins.push(stripTypesIfInferable);
   return {
@@ -33,53 +32,39 @@ function isEqual(a: ValueType, b: ValueType): boolean {
 }
 const initializedVariables = new Set<string>();
 const stripTypesIfInferable: Visitor = {
-  exit(path: Path) {
+  enter(path: Path) {
     const program = path.root.node;
     const node = path.node;
-    if (node.type === "Program") {
+    if (path.node.type === "Program") {
       initializedVariables.clear();
     } else if (
-      node.type === "Assignment" &&
-      node.variable.type === "Identifier" &&
-      !node.variable.builtin
+      node.type === "Identifier" &&
+      !node.builtin &&
+      path.parent !== null &&
+      path.parent.node.type === "Assignment" &&
+      path.pathFragment === "variable"
     ) {
-      const variable = node.variable.name;
+      const variable = node.name;
       if (
         program.variables.has(variable) &&
         !initializedVariables.has(variable)
       ) {
         if (
           !isEqual(
-            getType(node.expr, program),
+            getType(path.parent.node.expr, program),
             program.variables.get(variable)!
           )
         ) {
-          node.variable.valueType = program.variables.get(variable);
+          node.valueType = program.variables.get(variable);
+        } else {
+          node.valueType = undefined;
         }
         initializedVariables.add(variable);
       }
     } else if ("valueType" in node && node.valueType !== undefined) {
       if (isEqual(node.valueType, calcType(node, program))) {
-        path.replaceWith({ ...node, valueType: undefined });
+        node.valueType = undefined;
       }
-    }
-  },
-};
-
-const forceControlFlowBlocks: Visitor = {
-  enter(path: Path) {
-    if (path.parent !== null) {
-      const node = path.node;
-      if ("consequent" in node && node.consequent.type !== "Block")
-        path.replaceChild(variants([node.consequent]), "consequent");
-      if (
-        "alternate" in node &&
-        node.alternate !== undefined &&
-        node.alternate.type !== "Block"
-      )
-        path.replaceChild(variants([node.alternate]), "alternate");
-      if ("body" in node && node.body.type !== "Block")
-        path.replaceChild(variants([node.body]), "body");
     }
   },
 };

--- a/src/languages/polygolf/index.ts
+++ b/src/languages/polygolf/index.ts
@@ -1,0 +1,85 @@
+import { isSubtype, ValueType, variants } from "../../IR";
+import { Language } from "../../common/Language";
+
+import emitProgram from "./emit";
+import { Path, Visitor } from "common/traverse";
+import { calcType, getType } from "common/getType";
+
+function polygolfLanguage(stripTypes = false, forceBlocks = true): Language {
+  const plugins: Visitor[] = [];
+  if (stripTypes) plugins.push(stripTypesIfInferable);
+  if (forceBlocks) plugins.push(forceControlFlowBlocks);
+  plugins.push(blocksAsVariants);
+  return {
+    name: "Polygolf",
+    emitter: emitProgram,
+    plugins,
+  };
+}
+
+function isEqual(a: ValueType, b: ValueType): boolean {
+  return isSubtype(a, b) && isSubtype(b, a);
+}
+const initializedVariables = new Set<string>();
+const stripTypesIfInferable: Visitor = {
+  exit(path: Path) {
+    const program = path.root.node;
+    const node = path.node;
+    if (node.type === "Program") {
+      initializedVariables.clear();
+    } else if (
+      node.type === "Assignment" &&
+      node.variable.type === "Identifier" &&
+      !node.variable.builtin
+    ) {
+      const variable = node.variable.name;
+      if (
+        program.variables.has(variable) &&
+        !initializedVariables.has(variable)
+      ) {
+        if (
+          !isEqual(
+            getType(node.expr, program),
+            program.variables.get(variable)!
+          )
+        ) {
+          node.variable.valueType = program.variables.get(variable);
+        }
+        initializedVariables.add(variable);
+      }
+    } else if ("valueType" in node && node.valueType !== undefined) {
+      if (node.valueType === calcType(node, program)) {
+        node.valueType = undefined;
+      }
+    }
+  },
+};
+
+const forceControlFlowBlocks: Visitor = {
+  enter(path: Path) {
+    if (path.parent !== null) {
+      const node = path.node;
+      if ("consequent" in node && node.consequent.type !== "Block")
+        path.replaceChild(variants([node.consequent]), "consequent");
+      if (
+        "alternate" in node &&
+        node.alternate !== undefined &&
+        node.alternate.type !== "Block"
+      )
+        path.replaceChild(variants([node.alternate]), "alternate");
+      if ("body" in node && node.body.type !== "Block")
+        path.replaceChild(variants([node.body]), "body");
+    }
+  },
+};
+
+const blocksAsVariants: Visitor = {
+  exit(path: Path) {
+    const node = path.node;
+    if (node.type === "Block" && path.parent?.node.type !== "Variants") {
+      path.replaceWith(variants([node]));
+    }
+  },
+};
+
+export default polygolfLanguage;

--- a/src/languages/polygolf/index.ts
+++ b/src/languages/polygolf/index.ts
@@ -60,8 +60,10 @@ const stripTypesIfInferable: Visitor = {
           node.valueType = undefined;
         }
         initializedVariables.add(variable);
+        return;
       }
-    } else if ("valueType" in node && node.valueType !== undefined) {
+    }
+    if ("valueType" in node && node.valueType !== undefined) {
       if (isEqual(node.valueType, calcType(node, program))) {
         node.valueType = undefined;
       }


### PR DESCRIPTION
Adds polygolf as an implementation of `Language`.
Can choose if type annotations should be emitted everywhere, or only where they are neccessary.
Emits every valid Polygolf program to a valid Polygolf source code.
`parse` ∘ `x => applyLanguage(polygolf, x)` should be identity.

Furthermore, it can emit other programs (so those one containing nodes created by transforms) for debugging when writing languages / plugins. Such nodes are emitted using the `@` prefix.

For convenience when developing, adds a function `debug(program: Program)` which prints the argument emited to Polygolf.