### PR TITLE
Traverse improvements

### DIFF
--- a/src/common/traverse.ts
+++ b/src/common/traverse.ts
@@ -1,4 +1,4 @@
-import { IR } from "../IR";
+import { IR, Program } from "../IR";
 
 export class Path<N extends IR.Node = IR.Node> {
   _removed = false;
@@ -132,6 +132,12 @@ export class Path<N extends IR.Node = IR.Node> {
   visit(visitor: Visitor): void {
     try {
       if (this._removed) return;
+      if (visitor.enterProgram !== undefined) {
+        const node = this.node;
+        if (node.kind === "Program") {
+          visitor.enterProgram(node);
+        }
+      }
       visitor.enter?.(this);
       if (this._removed) return;
       this.visitState = {
@@ -259,6 +265,7 @@ export function programToPath(node: IR.Program) {
 
 export interface Visitor {
   name: string;
+  enterProgram?: (program: Program) => void; // this is executed at the start of entering the root node
   enter?: (path: Path) => void;
   exit?: (path: Path) => void;
   generatesVariants?: boolean;

--- a/src/common/traverse.ts
+++ b/src/common/traverse.ts
@@ -44,7 +44,11 @@ export class Path<N extends IR.Node = IR.Node> {
   }
 
   /** Replace this node's child given by pathFragment with newChild */
-  replaceChild(newChild: IR.Node, pathFragment: PathFragment): void {
+  replaceChild(
+    newChild: IR.Node,
+    pathFragment: PathFragment,
+    skipNewNode = false
+  ): void {
     if (newChild.kind === "Block" && this.node.kind === "Block") {
       this.replaceChildWithMultiple(newChild.children, pathFragment);
     } else {
@@ -54,7 +58,11 @@ export class Path<N extends IR.Node = IR.Node> {
         for (let i = queue.length - 1; i >= 0; i--) {
           if (queue[i].node === oldChild) {
             queue[i]._removed = true;
-            queue[i] = new Path(newChild, this, pathFragment);
+            if (skipNewNode) {
+              queue.splice(i, 1);
+            } else {
+              queue[i] = new Path(newChild, this, pathFragment);
+            }
             break;
           }
         }
@@ -103,11 +111,11 @@ export class Path<N extends IR.Node = IR.Node> {
   }
 
   /** Replace this node with newNode by mutating the parent */
-  replaceWith(newNode: IR.Node): void {
+  replaceWith(newNode: IR.Node, skipNewNode = false): void {
     this._removed = true;
     if (this.parent === null || this.pathFragment === null)
       throw new Error("Cannot replace the root node");
-    return this.parent.replaceChild(newNode, this.pathFragment);
+    return this.parent.replaceChild(newNode, this.pathFragment, skipNewNode);
   }
 
   /**
@@ -122,25 +130,32 @@ export class Path<N extends IR.Node = IR.Node> {
    * - more mutation issues probably
    */
   visit(visitor: Visitor): void {
-    if (this._removed) return;
-    visitor.enter?.(this);
-    if (this._removed) return;
-    this.visitState = {
-      queue: this.getChildPaths().reverse(),
-    };
-    let i = 1e3;
-    while (this.visitState.queue.length > 0 && --i > 0) {
-      const path = this.visitState.queue.at(-1)!;
-      path.visit(visitor);
-      if (!path._removed) {
-        this.visitState.queue.pop();
+    try {
+      if (this._removed) return;
+      visitor.enter?.(this);
+      if (this._removed) return;
+      this.visitState = {
+        queue: this.getChildPaths().reverse(),
+      };
+      let i = 1e3;
+      while (this.visitState.queue.length > 0 && --i > 0) {
+        const path = this.visitState.queue.at(-1)!;
+        path.visit(visitor);
+        if (!path._removed) {
+          this.visitState.queue.pop();
+        }
       }
+      if (i === 0)
+        throw new Error(
+          `Tree visit limit hit. This is probably due to a misbehaving plugin.`
+        );
+      visitor.exit?.(this);
+    } catch (e) {
+      if (e instanceof Error && this.node.kind === "Program") {
+        e.message = `Error in '${visitor.name}' visitor. ${e.message}`;
+      }
+      throw e;
     }
-    if (i === 0)
-      throw new Error(
-        `Tree visit limit hit. This is probably due to a misbehaving plugin (${visitor.name}).`
-      );
-    visitor.exit?.(this);
   }
 
   /** Returns an array of all nodes of a given type or satistifing given predicate. */

--- a/src/languages/nim/plugins.ts
+++ b/src/languages/nim/plugins.ts
@@ -36,25 +36,22 @@ const includes: [string, string[]][] = [
 
 export const addImports: Visitor = {
   name: "addImports",
-  exit(path: Path) {
-    if (path.node.kind === "Program") {
-      const program: Program = path.node;
-      const dependecies = [...program.dependencies];
-      if (dependecies.length < 1) return;
-      let imports: ImportStatement;
-      for (const include of includes) {
-        if (include[0].length > dependecies.join().length - 1) break;
-        if (dependecies.every((x) => include[1].includes(x))) {
-          imports = importStatement("include", [include[0]]);
-          break;
-        }
+  enterProgram(program: Program) {
+    const dependecies = [...program.dependencies];
+    if (dependecies.length < 1) return;
+    let imports: ImportStatement;
+    for (const include of includes) {
+      if (include[0].length > dependecies.join().length - 1) break;
+      if (dependecies.every((x) => include[1].includes(x))) {
+        imports = importStatement("include", [include[0]]);
+        break;
       }
-      imports ??= importStatement("import", dependecies);
-      program.body =
-        program.body.kind === "Block"
-          ? block([imports, ...program.body.children])
-          : block([imports, program.body]);
     }
+    imports ??= importStatement("import", dependecies);
+    program.body =
+      program.body.kind === "Block"
+        ? block([imports, ...program.body.children])
+        : block([imports, program.body]);
   },
 };
 

--- a/src/languages/nim/plugins.ts
+++ b/src/languages/nim/plugins.ts
@@ -47,7 +47,7 @@ export const addImports: Visitor = {
         break;
       }
     }
-    imports ??= importStatement("import", dependecies);
+    imports ??= importStatement("import", dependencies);
     program.body =
       program.body.kind === "Block"
         ? block([imports, ...program.body.children])

--- a/src/languages/nim/plugins.ts
+++ b/src/languages/nim/plugins.ts
@@ -37,12 +37,12 @@ const includes: [string, string[]][] = [
 export const addImports: Visitor = {
   name: "addImports",
   enterProgram(program: Program) {
-    const dependecies = [...program.dependencies];
-    if (dependecies.length < 1) return;
+    const dependencies = [...program.dependencies];
+    if (dependencies.length < 1) return;
     let imports: ImportStatement;
     for (const include of includes) {
-      if (include[0].length > dependecies.join().length - 1) break;
-      if (dependecies.every((x) => include[1].includes(x))) {
+      if (include[0].length > dependencies.join().length - 1) break;
+      if (dependencies.every((x) => include[1].includes(x))) {
         imports = importStatement("include", [include[0]]);
         break;
       }

--- a/src/plugins/idents.ts
+++ b/src/plugins/idents.ts
@@ -1,6 +1,6 @@
 import { IdentifierGenerator } from "common/Language";
 import { Path, Visitor } from "../common/traverse";
-import { IR } from "../IR";
+import { id, IR } from "../IR";
 
 function getIdentMap(
   path: Path<IR.Program>,
@@ -64,7 +64,7 @@ export function renameIdents(
         if (outputName === undefined) {
           throw new Error("Programming error. Incomplete identMap.");
         }
-        path.node.name = outputName;
+        path.replaceWith(id(outputName), true);
       }
     },
   };

--- a/src/plugins/print.ts
+++ b/src/plugins/print.ts
@@ -1,5 +1,5 @@
-import { Path, Visitor } from "common/traverse";
-import { polygolfOp, stringLiteral } from "../IR";
+import { Visitor } from "common/traverse";
+import { polygolfOp, Program, stringLiteral } from "../IR";
 import { mapOps } from "./ops";
 
 export const printLnToprint = mapOps([
@@ -17,23 +17,20 @@ export const printLnToprint = mapOps([
 export function golfLastPrint(toPrintln = true): Visitor {
   return {
     name: "golfLastPrint",
-    exit(path: Path) {
-      const node = path.node;
-      if (node.kind === "Program") {
+    enterProgram(program: Program) {
+      if (
+        program.body.kind === "PolygolfOp" &&
+        (program.body.op === "print" || program.body.op === "println")
+      ) {
+        program.body.op = toPrintln ? "println" : "print";
+      } else if (program.body.kind === "Block") {
+        const lastStatement =
+          program.body.children[program.body.children.length - 1];
         if (
-          node.body.kind === "PolygolfOp" &&
-          (node.body.op === "print" || node.body.op === "println")
+          lastStatement.kind === "PolygolfOp" &&
+          (lastStatement.op === "print" || lastStatement.op === "println")
         ) {
-          node.body.op = toPrintln ? "println" : "print";
-        } else if (node.body.kind === "Block") {
-          const lastStatement =
-            node.body.children[node.body.children.length - 1];
-          if (
-            lastStatement.kind === "PolygolfOp" &&
-            (lastStatement.op === "print" || lastStatement.op === "println")
-          ) {
-            lastStatement.op = toPrintln ? "println" : "print";
-          }
+          lastStatement.op = toPrintln ? "println" : "print";
         }
       }
     },


### PR DESCRIPTION
- add `skipNewNode` arg to `replaceWith` and `replaceChild`
- use the above to fix a bug in `renameIdents`
- add new function `enterProgram` to Visitor for code that should only be executed once