### PR TITLE
Add property

### DIFF
--- a/src/IR/exprs.ts
+++ b/src/IR/exprs.ts
@@ -148,7 +148,7 @@ export function methodCall(
   args: Expr[],
   ident: string | Identifier,
   op?: OpCode,
-  property?: boolean
+  property = false
 ): MethodCall {
   return {
     kind: "MethodCall",
@@ -156,7 +156,7 @@ export function methodCall(
     ident: typeof ident === "string" ? id(ident, true) : ident,
     object,
     args,
-    property: property === undefined ? false : property
+    property,
   };
 }
 

--- a/src/IR/exprs.ts
+++ b/src/IR/exprs.ts
@@ -40,6 +40,7 @@ export interface MethodCall extends BaseExpr {
   op: OpCode | null;
   object: Expr;
   args: Expr[];
+  property: boolean;
 }
 
 export interface IndexCall extends BaseExpr {
@@ -146,7 +147,8 @@ export function methodCall(
   object: Expr,
   args: Expr[],
   ident: string | Identifier,
-  op?: OpCode
+  op?: OpCode,
+  property?: boolean
 ): MethodCall {
   return {
     kind: "MethodCall",
@@ -154,6 +156,7 @@ export function methodCall(
     ident: typeof ident === "string" ? id(ident, true) : ident,
     object,
     args,
+    property: property === undefined ? false : property
   };
 }
 


### PR DESCRIPTION
Adds a boolean switch to MethodExpr to treat a method call as a property. Useful for languages such as C# and Swift. For example, Swift needs `text.count` rather than `text.count()`.