### PR TITLE
make *.test.md linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.test.md linguist-detectable


### PR DESCRIPTION
Includes *.test.md files in the lang stats since these files contribute to the build.