### PR TITLE
Fix #69

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "moduleResolution": "node",
     "skipLibCheck": true
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "exclude": ["./src/**/*.test.md.ts"]
 }


### PR DESCRIPTION
Fixes #69 by excluding `*.test.md.ts` files from build.