### PR TITLE
Swift bug fixes

### DIFF
--- a/src/languages/swift/emit.ts
+++ b/src/languages/swift/emit.ts
@@ -276,12 +276,26 @@ function emitExprNoParens(expr: IR.Expr): TokenTree {
         ),
         "]",
       ];
+    case "TableConstructor":
+      return [
+        "[",
+        joinTrees(
+          expr.kvPairs.map((x) => [
+            emitExprNoParens(x.key),
+            ":",
+            emitExprNoParens(x.value),
+          ]),
+          ","
+        ),
+        "]",
+      ];
     case "IndexCall":
       return [
         emitExprNoParens(expr.collection),
         "[",
         emitExprNoParens(expr.index),
         "]",
+        expr.collection.kind === "TableConstructor" ? "!" : "",
       ];
 
     default:

--- a/src/languages/swift/emit.ts
+++ b/src/languages/swift/emit.ts
@@ -200,7 +200,7 @@ function emitExprNoParens(expr: IR.Expr): TokenTree {
           ],
         ],
         [
-          `"""`,
+          [`"""\n`, `\n"""`],
           [
             [`\\`, `\\\\`],
             ...unicode01to09repls,

--- a/src/languages/swift/plugins.ts
+++ b/src/languages/swift/plugins.ts
@@ -18,7 +18,6 @@ export const addImports: Plugin = {
       if (dependencyMap.has(op)) {
         return dependencyMap.get(op)!;
       }
-      if (node.kind === "TableConstructor") return "tables";
     });
     const dependencies = [...new Set(dependenciesGen)];
     if (dependencies.length < 1) return;

--- a/src/languages/swift/swift.test.md
+++ b/src/languages/swift/swift.test.md
@@ -10,11 +10,11 @@ print (3+1);
 print(4)
 ```
 
+## Multiline string literals require newlines between delimiters and string content
+
 ```polygolf
 print "abc\ndef\nghi\njkl\nmno\npqr\nstu\nvwx\nyz!";
 ```
-
-## Multiline string literals require newlines between delimiters and string content
 
 ```swift bytes
 print("""

--- a/src/languages/swift/swift.test.md
+++ b/src/languages/swift/swift.test.md
@@ -1,6 +1,5 @@
 # Swift
 
-
 ## Multiline string literals require newlines between delimiters and string content
 
 ```polygolf

--- a/src/languages/swift/swift.test.md
+++ b/src/languages/swift/swift.test.md
@@ -1,9 +1,31 @@
 # Swift
 
+## Test eval static expr
+
 ```polygolf
 print (3+1);
 ```
 
 ```swift bytes
 print(4)
+```
+
+```polygolf
+print "abc\ndef\nghi\njkl\nmno\npqr\nstu\nvwx\nyz!";
+```
+
+## Multiline string literals require newlines between delimiters and string content
+
+```swift bytes
+print("""
+abc
+def
+ghi
+jkl
+mno
+pqr
+stu
+vwx
+yz!
+""")
 ```

--- a/src/languages/swift/swift.test.md
+++ b/src/languages/swift/swift.test.md
@@ -29,3 +29,15 @@ vwx
 yz!
 """)
 ```
+
+## Indexing a dictionary requires `!` to unwrap an Optional, unlike indexing a string or array
+
+```polygolf
+$a <- (text_get_byte "abc" 1);
+$b <- (table_get (table ("X" => "Y") ) "X");
+```
+
+```swift bytes
+a=Int(Array("abc".utf8)[1])
+b=["X":"Y"]["X"]!
+```

--- a/src/languages/swift/swift.test.md
+++ b/src/languages/swift/swift.test.md
@@ -1,14 +1,5 @@
 # Swift
 
-## Test eval static expr
-
-```polygolf
-print (3+1);
-```
-
-```swift bytes
-print(4)
-```
 
 ## Multiline string literals require newlines between delimiters and string content
 


### PR DESCRIPTION
Tackling a few bugs with the Swift lang:

- Improper multiline string emits (Fixed)
- Lacking support for tables (Fixed)
- Improper whitespace behavior, especially around symbols in `?!~-` (TODO)