### PR TITLE
Fix Golfscript identifier bug

### DIFF
--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -78,7 +78,17 @@ const golfscriptLanguage: Language = {
       ["argv_get", "a="],
     ]),
     addImports,
-    renameIdents(),
+    renameIdents({
+      // Custom Ident generator prevents `n` from being used as an ident, as it is predefined to newline and breaks printing if modified
+      preferred(original: string) {
+        if (/n/i.test(original[0])) return ["m", "M"];
+        const lower = original[0].toLowerCase();
+        const upper = original[0].toUpperCase();
+        return [original[0], original[0] === lower ? upper : lower];
+      },
+      short: "abcdefghijklmopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split(""),
+      general: (i: number) => "v" + i.toString(),
+    }),
   ],
   detokenizer: defaultDetokenizer(
     (a, b) =>

--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -81,7 +81,7 @@ const golfscriptLanguage: Language = {
     renameIdents({
       // Custom Ident generator prevents `n` from being used as an ident, as it is predefined to newline and breaks printing if modified
       preferred(original: string) {
-        if (/n/i.test(original[0])) return ["m", "M"];
+        if (/n/i.test(original[0])) return ["N", "m", "M"];
         const lower = original[0].toLowerCase();
         const upper = original[0].toUpperCase();
         return [original[0], original[0] === lower ? upper : lower];


### PR DESCRIPTION
Prevents golfscript from naming an identifier `n`, as `n` is a built-in which will break printing behavior if modified