### PR TITLE
Add finiteFlatten function

### DIFF
--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -44,9 +44,15 @@ export type TokenTree = string | TokenTreeArray;
 export type Detokenizer = (tokens: TokenTree) => string;
 export type WhitespaceInsertLogic = (a: string, b: string) => boolean;
 
-export function finiteFlatten(tokenTree: TokenTree): string[] {
-  if (typeof tokenTree === "string") return [tokenTree];
-  return tokenTree.map(finiteFlatten).flat(1);
+export function flattenTree(tokenTree: TokenTree): string[] {
+  var flattened: string[] = [];
+
+  function stepTree(t: TokenTree) {
+    if (typeof t === "string") flattened.push(t);
+    else t.map(stepTree);
+  }
+  stepTree(tokenTree);
+  return flattened;
 }
 
 export interface IdentifierGenerator {
@@ -70,7 +76,7 @@ export function defaultDetokenizer(
   indent = 1
 ): Detokenizer {
   return function (tokenTree: TokenTree): string {
-    const tokens: string[] = finiteFlatten(tokenTree);
+    const tokens: string[] = flattenTree(tokenTree);
     let indentLevel = 0;
     let result = tokens[0];
     for (let i = 1; i < tokens.length; i++) {

--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -44,6 +44,11 @@ export type TokenTree = string | TokenTreeArray;
 export type Detokenizer = (tokens: TokenTree) => string;
 export type WhitespaceInsertLogic = (a: string, b: string) => boolean;
 
+export function finiteFlatten(tokenTree: TokenTree): string[] {
+  if (typeof tokenTree === "string") return [tokenTree];
+  return tokenTree.map(finiteFlatten).flat(1);
+}
+
 export interface IdentifierGenerator {
   preferred: (original: string) => string[];
   short: string[];
@@ -65,8 +70,7 @@ export function defaultDetokenizer(
   indent = 1
 ): Detokenizer {
   return function (tokenTree: TokenTree): string {
-    // @ts-expect-error
-    const tokens: string[] = [tokenTree].flat(Infinity); // it seems ts doesn't understand flattening the tree
+    const tokens: string[] = finiteFlatten([tokenTree]);
     let indentLevel = 0;
     let result = tokens[0];
     for (let i = 1; i < tokens.length; i++) {

--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -70,7 +70,7 @@ export function defaultDetokenizer(
   indent = 1
 ): Detokenizer {
   return function (tokenTree: TokenTree): string {
-    const tokens: string[] = finiteFlatten([tokenTree]);
+    const tokens: string[] = finiteFlatten(tokenTree);
     let indentLevel = 0;
     let result = tokens[0];
     for (let i = 1; i < tokens.length; i++) {


### PR DESCRIPTION
Using the builtin `flat` method on `tokenTree` caused TypeScript to throw `Type instantiation is excessively deep and possibly infinite.ts(2589)`. This introduces a `finiteFlatten` method which TypeScript is ok with.