### PR TITLE
Add Int ̵&̵ ̵N̵a̵t̵ type aliases

### DIFF
--- a/src/frontend/lexer.ts
+++ b/src/frontend/lexer.ts
@@ -4,7 +4,7 @@ const tokenTable = {
   integer: /-?[0-9]+/,
   string: /"(?:\\.|[^"])*"/,
   variable: /\$\w+/,
-  type: ["Void", "Text", "Bool", "List", "Table", "Array", "Set", "Func"],
+  type: /[A-Z][a-z]*/,
   argv_get: "argv_get",
   nullary: ["argv", "argc", "true", "false"],
   ninf: ["-oo", "-∞"],
@@ -13,7 +13,7 @@ const tokenTable = {
   opalias: "<- + - * ^ & | ~ == != <= < >= > => # mod rem div trunc_div".split(
     " "
   ),
-  builtin: /\w+/,
+  builtin: /[a-z0-9_]+/,
   lparen: "(",
   rparen: ")",
   lbrace: "{",

--- a/src/frontend/parse.ts
+++ b/src/frontend/parse.ts
@@ -247,9 +247,6 @@ export function typeSexpr(
     case "Int":
       expectArity(0);
       return intType();
-    case "Nat":
-      expectArity(0);
-      return intType(0);
     case "Ascii":
     case "Text":
       expectArity(0, 1);

--- a/src/frontend/parse.ts
+++ b/src/frontend/parse.ts
@@ -241,6 +241,12 @@ export function typeSexpr(
     case "Void":
       expectArity(0);
       return voidType;
+    case "Int":
+      expectArity(0);
+      return intType();
+    case "Nat":
+      expectArity(0);
+      return intType(0);
     case "Text":
       expectArity(0, 1);
       if (args.length === 0) return textType();


### PR DESCRIPTION
Related issue #133 .
Also makes all words starting with a capital lex as types and doesn't allow capital letters in builtin tokens.