### PR TITLE
Emit negative polynomial terms last

### DIFF
--- a/src/IR/associativeOpsRepr.test.md
+++ b/src/IR/associativeOpsRepr.test.md
@@ -27,7 +27,7 @@ print ((($a + 5) + $c) + 4);
 $a:-oo..oo <- 0;
 $b:-oo..oo <- 0;
 $c:-oo..oo <- 0;
-print (+ $a $c 9);
+print (+ 9 $a $c);
 ```
 
 ```polygolf
@@ -41,7 +41,7 @@ print (((4 * $a) + 3) - $a);
 $a:-oo..oo <- 0;
 $b:-oo..oo <- 0;
 $c:-oo..oo <- 0;
-print ((3 * $a) + 3);
+print (3 + (3 * $a));
 ```
 
 ```polygolf

--- a/src/IR/exprs.ts
+++ b/src/IR/exprs.ts
@@ -38,7 +38,7 @@ export interface KeyValue extends BaseExpr {
  * - PolygolfOp(neg)
  * - PolygolfOp(sub)
  * - PolygolfOp as a direct child of a PolygolfOp with the same associative OpCode
- * - IntegerLiteral as a nonfirst child of an associative PolygolfOp
+ * - IntegerLiteral as a nonfirst child of a commutative PolygolfOp
  * 
  * This is ensured when using the polygolfOp contructor function and the Spine API so avoid creating such nodes manually.
  */

--- a/src/IR/exprs.ts
+++ b/src/IR/exprs.ts
@@ -35,10 +35,10 @@ export interface KeyValue extends BaseExpr {
  * This is used to represent an abstract operation.
  * Polygolf ensures that in the IR, there will never be:
 
- * Polygolf(neg)
- * Polygolf(sub)
- * Polygolf(add) as a direct child of Polygolf(add) - same with all other associative ops
- * IntegerLiteral (if present) appears at the first position in the args list
+ * - PolygolfOp(neg)
+ * - PolygolfOp(sub)
+ * - PolygolfOp as a direct child of a PolygolfOp with the same associative OpCode
+ * - IntegerLiteral as a nonfirst child of an associative PolygolfOp
  * 
  * This is ensured when using the polygolfOp contructor function and the Spine API so avoid creating such nodes manually.
  */

--- a/src/IR/exprs.ts
+++ b/src/IR/exprs.ts
@@ -173,7 +173,7 @@ export function polygolfOp(op: OpCode, ...args: Expr[]): Expr {
         } else newArgs.push(arg);
       }
       args = newArgs;
-      if (op === "mul" && args.length === 2 && isIntLiteral(args[0], 1n)) {
+      if (op === "mul" && args.length > 1 && isIntLiteral(args[0], 1n)) {
         args = args.slice(1);
       } else if (
         op === "mul" &&

--- a/src/languages/golfscript/golfscript.test.md
+++ b/src/languages/golfscript/golfscript.test.md
@@ -24,7 +24,7 @@ for $i 0 31 {
 ```
 
 ```golfscript bytes
-31,{:i;i i i*+1+puts}%
+31,{:i;1 i+i i*+puts}%
 ```
 
 ```polygolf

--- a/src/languages/lua/lua.test.md
+++ b/src/languages/lua/lua.test.md
@@ -58,7 +58,7 @@ a=0
 b="xy"
 ~a
 -a
-a+2
+2+a
 a-2
 2*a
 a//2
@@ -113,6 +113,6 @@ for_argv $x 100 {
 ```
 
 ```lua nogolf
-for x=0,99 do X=arg[x+1]
+for x=0,99 do X=arg[1+x]
 print(X)end
 ```

--- a/src/languages/nim/nim.test.md
+++ b/src/languages/nim/nim.test.md
@@ -84,7 +84,7 @@ n/%3
 n%%3
 n shl 3
 n shr 3
-n+3
+3+n
 n-3
 3 and n
 3 or n
@@ -117,7 +117,7 @@ println (($a + 1) * $a);
 
 ```nim nogolf
 var a=0
-echo (a+1)*a
+echo (1+a)*a
 ```
 
 ```polygolf

--- a/src/languages/swift/swift.test.md
+++ b/src/languages/swift/swift.test.md
@@ -68,7 +68,7 @@ if a != 0{a=1}
 if a != -12{a=1}
 if -3 != a{a=1}
 for d in -4..<4{a=d}
-for e in(a+1)*(a+1)..<99{a=1}
+for e in(1+a)*(1+a)..<99{a=1}
 ```
 
 ## Argv

--- a/src/plugins/binaryOps.test.md
+++ b/src/plugins/binaryOps.test.md
@@ -14,7 +14,7 @@ $x <- ("prepend" .. $x);
 $n:-oo..oo <- 0;
 $a:-oo..oo <- 0;
 @MutatingBinaryOp add + $n 3;
-@MutatingBinaryOp add + $n ($a + 3);
+@MutatingBinaryOp add + $n (3 + $a);
 $x:Text <- "hello";
 @MutatingBinaryOp concat + $x " world";
 $x <- ("prepend" .. $x);

--- a/src/plugins/loops.test.md
+++ b/src/plugins/loops.test.md
@@ -18,12 +18,12 @@ for $i 0 10 {
 $i <- 0;
 while ($i < 10) {
   print $x;
-  $i <- ($i + 1);
+  $i <- (1 + $i);
 };
 ```
 
 ```polygolf loops.forRangeToForCLike
-@ForCLike ($i <- 0) ($i < 10) ($i <- ($i + 1)) (
+@ForCLike ($i <- 0) ($i < 10) ($i <- (1 + $i)) (
   print $x
 );
 ```
@@ -112,11 +112,11 @@ for $i 0 80 {
 for $iPOLYGOLFshifted 1 81 {
   println $iPOLYGOLFshifted;
   println $iPOLYGOLFshifted;
-  println (3 * ($iPOLYGOLFshifted + -1));
-  println ($iPOLYGOLFshifted + 1);
-  println ($iPOLYGOLFshifted + -2);
-  println ($iPOLYGOLFshifted + -3);
-  println ((-1 * $iPOLYGOLFshifted) + 2);
+  println (3 * (-1 + $iPOLYGOLFshifted));
+  println (1 + $iPOLYGOLFshifted);
+  println (-2 + $iPOLYGOLFshifted);
+  println (-3 + $iPOLYGOLFshifted);
+  println (2 + (-1 * $iPOLYGOLFshifted));
   println (-1 * $iPOLYGOLFshifted);
 };
 ```

--- a/src/plugins/ops.ts
+++ b/src/plugins/ops.ts
@@ -71,11 +71,7 @@ function asBinaryChain(
   names: Map<OpCode, string>
 ): Expr {
   if (op === "mul" && isIntLiteral(exprs[0], -1n)) {
-    return unaryOp(
-      "neg",
-      polygolfOp("mul", ...exprs.slice(1)),
-      names.get("neg")
-    );
+    exprs = [unaryOp("neg", exprs[1], names.get("neg")), ...exprs.slice(2)];
   }
   if (op === "add") {
     exprs = exprs

--- a/src/plugins/ops.ts
+++ b/src/plugins/ops.ts
@@ -11,6 +11,7 @@ import {
   isBinary,
   isConstantType,
   isIntLiteral,
+  isNegative,
   OpCode,
   PolygolfOp,
   polygolfOp,
@@ -76,27 +77,20 @@ function asBinaryChain(
       names.get("neg")
     );
   }
+  if (op === "add") {
+    exprs = exprs
+      .filter((x) => !isNegative(x))
+      .concat(exprs.filter(isNegative));
+  }
   let result = exprs[0];
   for (const expr of exprs.slice(1)) {
-    if (
-      op === "add" &&
-      expr.kind === "PolygolfOp" &&
-      expr.op === "mul" &&
-      isIntLiteral(expr.args[0]) &&
-      expr.args[0].value < 0n
-    ) {
+    if (op === "add" && isNegative(expr)) {
       result = binaryOp(
         "sub",
         result,
         polygolfOp("neg", expr),
         names.get("sub")
       );
-    } else if (
-      op === "add" &&
-      expr.kind === "IntegerLiteral" &&
-      expr.value < 0n
-    ) {
-      result = binaryOp("sub", result, int(-expr.value), names.get("sub"));
     } else {
       result = binaryOp(op, result, expr, names.get(op));
     }

--- a/src/plugins/ops.ts
+++ b/src/plugins/ops.ts
@@ -70,7 +70,7 @@ function asBinaryChain(
   exprs: readonly Expr[],
   names: Map<OpCode, string>
 ): Expr {
-  if (op === "mul" && isIntLiteral(exprs[0]) && exprs[0].value < 0n) {
+  if (op === "mul" && isIntLiteral(exprs[0], -1n)) {
     return unaryOp(
       "neg",
       polygolfOp("mul", ...exprs.slice(1)),


### PR DESCRIPTION
- Patches `mapToUnaryAndBinaryOps` so that negative terms in a polynomial are always placed last.
- Enforces the invariant
> IntegerLiteral (if present) appears at the first position in the args list

for `polygolfOp` of type `add` as well.