### PR TITLE
Fix #140

### DIFF
--- a/src/languages/swift/index.ts
+++ b/src/languages/swift/index.ts
@@ -199,13 +199,17 @@ const swiftLanguage: Language = {
       return /[A-Za-z0-9]/.test(s);
     }
 
-    // A binary op followed by a unary op needs whitespace on both sides, and `!=` always needs it
+    // Tokens that need whitespace on both sides:
+    //   A binary op followed by a unary op
+    //   `!=`
+    //   `&` followed by any of `*+-` (without space they are interpreted together as an overflow operator)
     function needsWhiteSpaceOnBothSides(
       token: string,
       nextToken: string
     ): boolean {
       return (
         (/^[-+*/<>=^*|~]+$/.test(token) && /[-~]/.test(nextToken[0])) ||
+        (token === `&` && /[*+-]/.test(nextToken[0])) ||
         token === `!=`
       );
     }


### PR DESCRIPTION
prevents `&+`, `&-` and `&*` from being emitted in Swift as these are treated by the language as overflow operators

edit so Github links to the issue:
Fixes #140 