### PR TITLE
Fix #209

### DIFF
--- a/src/plugins/ops.ts
+++ b/src/plugins/ops.ts
@@ -182,7 +182,7 @@ export function addMutatingBinaryOp(
           return mutatingBinaryOp(
             op,
             node.variable,
-            args.length > 1 ? polygolfOp(op, ...newArgs) : newArgs[0],
+            newArgs.length > 1 ? polygolfOp(op, ...newArgs) : newArgs[0],
             name
           );
         }


### PR DESCRIPTION
Fixes #209

It appears this bug went uncaught in tests of the mutating binary op plugin because it was only tested on associative/variadic arity operators.