### PR TITLE
Text replace op

### DIFF
--- a/src/IR/opcodes.ts
+++ b/src/IR/opcodes.ts
@@ -217,7 +217,7 @@ export const OpCodes = [
   "argv",
   "argc",
   "text_replace",
-  "text_multireplace",
+  "text_multireplace", // simultaneous replacement. Equivalent to chained text_replace if the inputs and outputs have no overlap
   "text_get_codepoint_slice", // Returns a slice of the input text. Indeces are codepoint-0-based, start is inclusive, end is exclusive.
   "text_get_byte_slice", // Returns a slice of the input text. Indeces are byte-0-based, start is inclusive, end is exclusive.
   // collection set

--- a/src/IR/opcodes.ts
+++ b/src/IR/opcodes.ts
@@ -217,6 +217,7 @@ export const OpCodes = [
   "argv",
   "argc",
   "text_replace",
+  "text_multireplace",
   "text_get_codepoint_slice", // Returns a slice of the input text. Indeces are codepoint-0-based, start is inclusive, end is exclusive.
   "text_get_byte_slice", // Returns a slice of the input text. Indeces are byte-0-based, start is inclusive, end is exclusive.
   // collection set
@@ -252,6 +253,7 @@ export function arity(op: OpCode): number {
     case "table_set":
       return 3;
     case "println_many_joined_using":
+    case "text_multireplace":
       return -1;
   }
 }

--- a/src/common/getType.ts
+++ b/src/common/getType.ts
@@ -259,9 +259,16 @@ function getTypeBitNot(t: IntegerType): IntegerType {
 
 function getOpCodeType(expr: PolygolfOp, program: Program): Type {
   const types = getArgs(expr).map((x) => getType(x, program));
-  function expectVariadicType(expected: Type, minArity = 2) {
+  function expectVariadicType(
+    expected: Type,
+    minArityOrArityCheck: number | ((x: number) => boolean) = 2
+  ) {
+    const arityCheck =
+      typeof minArityOrArityCheck === "number"
+        ? (x: number) => x >= minArityOrArityCheck
+        : minArityOrArityCheck;
     if (
-      types.length < minArity ||
+      !arityCheck(types.length) ||
       types.some((x, i) => !isSubtype(x, expected))
     ) {
       throw new PolygolfError(
@@ -657,6 +664,9 @@ function getOpCodeType(expr: PolygolfOp, program: Program): Type {
         a.isAscii && c.isAscii
       );
     }
+    case "text_multireplace":
+      expectVariadicType(textType(), (x) => x > 2 && x % 2 > 0);
+      return textType();
     case "text_get_byte_slice":
     case "text_get_codepoint_slice": {
       expectType(textType(), integerType(0), integerType(0));

--- a/src/frontend/parse.ts
+++ b/src/frontend/parse.ts
@@ -157,7 +157,8 @@ export function sexpr(callee: Identifier, args: readonly Expr[]): Expr {
       expectArity(2, isAssociative(opCode) ? Infinity : 2);
       return polygolfOp(opCode, ...args);
     }
-    expectArity(arity(opCode));
+    const ar = arity(opCode);
+    expectArity(ar, ar === -1 ? Infinity : ar);
     return polygolfOp(opCode, ...args);
   }
   throw new PolygolfError(

--- a/src/languages/lua/index.ts
+++ b/src/languages/lua/index.ts
@@ -119,6 +119,35 @@ const luaLanguage: Language = {
       ["max", (x) => functionCall(x, "math.max")],
       ["abs", (x) => functionCall(x, "math.abs")],
       ["int_to_text_byte", (x) => functionCall(x, "string.char")],
+      [
+        "text_replace",
+        ([a, b, c]) =>
+          methodCall(
+            a,
+            [
+              b.kind === "StringLiteral"
+                ? stringLiteral(
+                    b.value.replace(
+                      /(-|%|\^|\$|\(|\)|\.|\[|\]|\*|\+|\?)/g,
+                      "%$1"
+                    )
+                  )
+                : methodCall(
+                    b,
+                    [stringLiteral("(%W)"), stringLiteral("%%%1")],
+                    "gsub"
+                  ),
+              c.kind === "StringLiteral"
+                ? stringLiteral(c.value.replace("%", "%%"))
+                : methodCall(
+                    c,
+                    [stringLiteral("%%"), stringLiteral("%%%%")],
+                    "gsub"
+                  ),
+            ],
+            "gsub"
+          ),
+      ],
     ]),
     mapToUnaryAndBinaryOps(
       ["pow", "^"],

--- a/src/languages/lua/lua.test.md
+++ b/src/languages/lua/lua.test.md
@@ -51,6 +51,9 @@ concat $b "xyz";
 text_byte_length "abc";
 int_to_text 5;
 text_to_int "5";
+text_replace $b "a" "A";
+text_replace $b "(" "*";
+text_replace $b $b:(Text 1..oo) $b;
 ```
 
 ```lua nogolf
@@ -80,6 +83,9 @@ b.."xyz"
 ("abc"):len()
 ""..5
 1*"5"
+b:gsub("a","A")
+b:gsub("%(","*")
+b:gsub(b:gsub("(%W)","%%%1"),b:gsub("%%","%%%%"))
 ```
 
 ## Parentheses

--- a/src/languages/nim/emit.ts
+++ b/src/languages/nim/emit.ts
@@ -1,6 +1,6 @@
 import { TokenTree } from "@/common/Language";
 import { emitStringLiteral, joinTrees, EmitError } from "../../common/emit";
-import { IR, isIntLiteral } from "../../IR";
+import { ArrayConstructor, IR, isIntLiteral } from "../../IR";
 
 function precedence(expr: IR.Expr): number {
   switch (expr.kind) {
@@ -275,6 +275,23 @@ function emit(expr: IR.Expr, minimumPrec = -Infinity): TokenTree {
         return [e.name, emit(e.arg, prec)];
       case "ListConstructor":
         return ["@", "[", joinExprs(",", e.exprs), "]"];
+      case "ArrayConstructor":
+        if (
+          e.exprs.every(
+            (x) => x.kind === "ArrayConstructor" && x.exprs.length === 2
+          )
+        ) {
+          const pairs = e.exprs as readonly ArrayConstructor[];
+          return [
+            "{",
+            joinTrees(
+              ",",
+              pairs.map((x) => [emit(x.exprs[0]), ":", emit(x.exprs[1])])
+            ),
+            "}",
+          ];
+        }
+        return ["[", joinExprs(",", e.exprs), "]"];
       case "TableConstructor":
         return [
           "{",

--- a/src/languages/nim/index.ts
+++ b/src/languages/nim/index.ts
@@ -114,6 +114,16 @@ const nimLanguage: Language = {
       ["abs", (x) => functionCall(x, "abs")],
       ["bool_to_int", (x) => functionCall(x, "int")],
       ["int_to_text_byte", (x) => functionCall(x, "chr")],
+      [
+        "text_replace",
+        (x) =>
+          functionCall(
+            x[2].kind === "StringLiteral" && x[2].value === ""
+              ? [x[0], x[1]]
+              : x,
+            "replace"
+          ),
+      ],
     ]),
     useUnsignedDivision,
     addMutatingBinaryOp(

--- a/src/languages/nim/index.ts
+++ b/src/languages/nim/index.ts
@@ -79,7 +79,7 @@ const nimLanguage: Language = {
     applyDeMorgans,
     textToIntToTextGetToInt,
     forRangeToForRangeOneStep,
-    useMultireplace,
+    useMultireplace(),
   ],
   emitPlugins: [
     forArgvToForEach,

--- a/src/languages/nim/index.ts
+++ b/src/languages/nim/index.ts
@@ -5,6 +5,7 @@ import {
   int,
   rangeIndexCall,
   add1,
+  arrayConstructor,
 } from "../../IR";
 import { defaultDetokenizer, Language } from "../../common/Language";
 
@@ -39,6 +40,7 @@ import {
   textGetToIntToTextGet,
   textToIntToTextGetToInt,
   useEquivalentTextOp,
+  useMultireplace,
 } from "../../plugins/textOps";
 import { assertInt64 } from "../../plugins/types";
 import {
@@ -77,6 +79,7 @@ const nimLanguage: Language = {
     applyDeMorgans,
     textToIntToTextGetToInt,
     forRangeToForRangeOneStep,
+    useMultireplace,
   ],
   emitPlugins: [
     forArgvToForEach,
@@ -122,6 +125,21 @@ const nimLanguage: Language = {
               ? [x[0], x[1]]
               : x,
             "replace"
+          ),
+      ],
+      [
+        "text_multireplace",
+        (x) =>
+          functionCall(
+            [
+              x[0],
+              arrayConstructor(
+                x.flatMap((_, i) =>
+                  i % 2 > 0 ? [arrayConstructor(x.slice(i, i + 2))] : []
+                ) // Polygolf doesn't have array of tuples, so we use array of arrays instead
+              ),
+            ],
+            "multireplace"
           ),
       ],
     ]),
@@ -188,7 +206,7 @@ const nimLanguage: Language = {
     if (
       /[A-Za-z]/.test(left) &&
       !["var", "in", "else", "if", "while", "for"].includes(a) &&
-      (symbols + `"(`).includes(right) &&
+      (symbols + `"({`).includes(right) &&
       !["=", ":", ".", "::"].includes(b)
     )
       return true; // identifier meeting an operator or string literal or opening paren

--- a/src/languages/nim/nim.test.md
+++ b/src/languages/nim/nim.test.md
@@ -23,6 +23,8 @@ println $t;
 bool_to_int $b;
 int_to_text_byte 48;
 $t .. "x";
+text_replace "a+b+c" "+" "*";
+text_replace "a*b*c" "*" "";
 
 ~ $n;
 not $b;
@@ -76,6 +78,8 @@ t.echo
 b.int
 48.chr
 t&"x"
+"a+b+c".replace("+","*")
+"a*b*c".replace"*"
 not n
 not b
 -n

--- a/src/languages/nim/nim.test.md
+++ b/src/languages/nim/nim.test.md
@@ -25,6 +25,7 @@ int_to_text_byte 48;
 $t .. "x";
 text_replace "a+b+c" "+" "*";
 text_replace "a*b*c" "*" "";
+text_multireplace "XYZXYZ" "Y" "b" "X" "a";
 
 ~ $n;
 not $b;
@@ -80,6 +81,7 @@ b.int
 t&"x"
 "a+b+c".replace("+","*")
 "a*b*c".replace"*"
+"XYZXYZ".multireplace {"Y":"b","X":"a"}
 not n
 not b
 -n

--- a/src/languages/nim/plugins.ts
+++ b/src/languages/nim/plugins.ts
@@ -36,6 +36,8 @@ export const addNimImports: Plugin = addImports(
   [
     ["^", "math"],
     ["repeat", "strutils"],
+    ["replace", "strutils"],
+    ["multireplace", "strutils"],
     ["paramStr", "os"],
     ["commandLineParams", "os"],
     ["split", "strutils"],

--- a/src/languages/python/emit.ts
+++ b/src/languages/python/emit.ts
@@ -195,6 +195,15 @@ function emit(expr: IR.Expr, minimumPrec = -Infinity): TokenTree {
         return [e.name, emit(e.arg, prec)];
       case "ListConstructor":
         return ["[", joinExprs(",", e.exprs), "]"];
+      case "TableConstructor":
+        return [
+          "{",
+          joinTrees(
+            ",",
+            e.kvPairs.map((x) => [emit(x.key), ":", emit(x.value)])
+          ),
+          "}",
+        ];
       case "IndexCall":
         if (e.oneIndexed) throw new EmitError(expr, "one indexed");
         return [emit(e.collection, Infinity), "[", emit(e.index), "]"];

--- a/src/languages/python/index.ts
+++ b/src/languages/python/index.ts
@@ -129,6 +129,7 @@ const pythonLanguage: Language = {
           );
         },
       ],
+      ["text_replace", (x) => methodCall(x[0], [x[1], x[2]], "replace")],
     ]),
     addMutatingBinaryOp(
       ["add", "+"],

--- a/src/languages/python/index.ts
+++ b/src/languages/python/index.ts
@@ -11,6 +11,9 @@ import {
   textType,
   namedArg,
   add1,
+  tableConstructor,
+  keyValue,
+  StringLiteral,
 } from "../../IR";
 import { Language } from "../../common/Language";
 
@@ -40,6 +43,7 @@ import {
   textGetToIntToTextGet,
   textToIntToTextGetToInt,
   useEquivalentTextOp,
+  useMultireplace,
 } from "../../plugins/textOps";
 import {
   addOneToManyAssignments,
@@ -52,6 +56,7 @@ import {
   equalityToInequality,
   useIntegerTruthiness,
 } from "../../plugins/arithmetic";
+import { charLength } from "../../common/applyLanguage";
 
 const pythonLanguage: Language = {
   name: "Python",
@@ -70,6 +75,7 @@ const pythonLanguage: Language = {
     applyDeMorgans,
     useIntegerTruthiness,
     forRangeToForRangeOneStep,
+    useMultireplace(true),
   ],
   emitPlugins: [
     forArgvToForEach,
@@ -130,6 +136,31 @@ const pythonLanguage: Language = {
         },
       ],
       ["text_replace", (x) => methodCall(x[0], [x[1], x[2]], "replace")],
+      [
+        "text_multireplace",
+        (x) =>
+          methodCall(
+            x[0],
+            [
+              tableConstructor(
+                (x as StringLiteral[]).flatMap((_, i, x) =>
+                  i % 2 > 0
+                    ? [
+                        keyValue(
+                          int(x[i].value.codePointAt(0)!),
+                          charLength(x[i + 1].value) === 1 &&
+                            x[i + 1].value.codePointAt(0)! < 100
+                            ? int(x[i + 1].value.codePointAt(0)!)
+                            : x[i + 1]
+                        ),
+                      ]
+                    : []
+                )
+              ),
+            ],
+            "translate"
+          ),
+      ],
     ]),
     addMutatingBinaryOp(
       ["add", "+"],

--- a/src/languages/python/python.test.md
+++ b/src/languages/python/python.test.md
@@ -188,3 +188,13 @@ if true {
 if 1:print("a")
 elif 1:print("b")
 ```
+
+## Multireplace
+
+```polygolf
+text_replace (text_replace (text_replace "text" "x" "s") "t" "ttt") "e" " ";
+```
+
+```py
+"text".translate({120:"s",116:"ttt",101:32})
+```

--- a/src/languages/swift/index.ts
+++ b/src/languages/swift/index.ts
@@ -153,6 +153,15 @@ const swiftLanguage: Language = {
       ["abs", (x) => functionCall([x[0]], "abs")],
       ["true", (_) => id("true", true)],
       ["false", (_) => id("false", true)],
+      [
+        "text_replace",
+        (x) =>
+          methodCall(
+            x[0],
+            [namedArg("of", x[1]), namedArg("with", x[2])],
+            "replacingOccurrences"
+          ),
+      ],
     ]),
     addMutatingBinaryOp(
       ["add", "+"],

--- a/src/languages/swift/index.ts
+++ b/src/languages/swift/index.ts
@@ -199,7 +199,13 @@ const swiftLanguage: Language = {
       ["and", "&&"],
       ["or", "||"]
     ),
-    addImports([["pow", "Foundation"]], "import"),
+    addImports(
+      [
+        ["pow", "Foundation"],
+        ["replacingOccurrences", "Foundation"],
+      ],
+      "import"
+    ),
     renameIdents(),
     addVarDeclarations,
     groupVarDeclarations(),

--- a/src/languages/swift/swift.test.md
+++ b/src/languages/swift/swift.test.md
@@ -103,6 +103,7 @@ int_to_text 5;
 text_to_int "5";
 text_split "xyz" "y";
 repeat $b 3;
+text_replace "a+b+c" "+" "*";
 table_get (table ("X" => "Y") ) "X";
 and $c $c;
 or $c $c;
@@ -153,6 +154,7 @@ String(5)
 Int("5")!
 "xyz".split(separator:"y")
 String(repeating:b,count:3)
+"a+b+c".replacingOccurrences(of:"+", with:"*")
 ["X":"Y"]["X"]!
 c&&c
 c||c

--- a/src/plugins/textOps.test.md
+++ b/src/plugins/textOps.test.md
@@ -35,13 +35,21 @@ int_to_codepoint 150;
 ```
 
 ```polygolf
-text_replace (text_replace "ABCD" "A" "a") "B" "b";
+text_replace (text_replace "ABCD" "A" "a") "BC" "b";
 text_replace (text_replace "ABCD" "A" "a") "a" "b";
 text_replace (text_replace "ABCD" "A" "a") "A" "b";
 ```
 
-```polygolf textOps.useMultireplace
-text_multireplace "ABCD" "A" "a" "B" "b";
+```polygolf textOps.useMultireplace(false)
+text_multireplace "ABCD" "A" "a" "BC" "b";
 text_replace (text_replace "ABCD" "A" "a") "a" "b";
 text_replace (text_replace "ABCD" "A" "a") "A" "b";
+```
+
+```polygolf
+text_replace (text_replace "ABCD" "A" "a") "BC" "b";
+```
+
+```polygolf textOps.useMultireplace(true)
+text_replace (text_replace "ABCD" "A" "a") "BC" "b";
 ```

--- a/src/plugins/textOps.test.md
+++ b/src/plugins/textOps.test.md
@@ -33,3 +33,15 @@ text_codepoint_length "ěščřžýáíé";
 int_to_text_byte 48;
 int_to_codepoint 150;
 ```
+
+```polygolf
+text_replace (text_replace "ABCD" "A" "a") "B" "b";
+text_replace (text_replace "ABCD" "A" "a") "a" "b";
+text_replace (text_replace "ABCD" "A" "a") "A" "b";
+```
+
+```polygolf textOps.useMultireplace
+text_multireplace "ABCD" "A" "a" "B" "b";
+text_replace (text_replace "ABCD" "A" "a") "a" "b";
+text_replace (text_replace "ABCD" "A" "a") "A" "b";
+```

--- a/src/plugins/textOps.ts
+++ b/src/plugins/textOps.ts
@@ -93,3 +93,19 @@ export const textToIntToTextGetToInt: Plugin = {
   ]),
   name: "textToIntToTextGetToInt",
 };
+
+export const useMultireplace: Plugin = {
+  name: "useMultireplace",
+  visit(node) {
+    if (
+      isPolygolfOp(node, "text_replace", "text_multireplace") &&
+      isPolygolfOp(node.args[0], "text_replace", "text_multireplace")
+    ) {
+      return polygolfOp(
+        "text_multireplace",
+        ...node.args[0].args,
+        ...node.args.slice(1)
+      );
+    }
+  },
+};

--- a/src/plugins/textOps.ts
+++ b/src/plugins/textOps.ts
@@ -9,6 +9,7 @@ import {
 } from "../IR";
 import { Plugin } from "../common/Language";
 import { mapOps } from "./ops";
+import { charLength } from "../common/applyLanguage";
 
 function toBidirectionalMap<T>(pairs: [T, T][]): Map<T, T> {
   return new Map<T, T>([...pairs, ...pairs.map<[T, T]>(([k, v]) => [v, k])]);
@@ -95,33 +96,48 @@ export const textToIntToTextGetToInt: Plugin = {
   name: "textToIntToTextGetToInt",
 };
 
-export const useMultireplace: Plugin = {
-  name: "useMultireplace",
-  visit(node) {
-    if (
-      isPolygolfOp(node, "text_replace", "text_multireplace") &&
-      isPolygolfOp(node.args[0], "text_replace", "text_multireplace")
-    ) {
-      const a = node.args[0].args.slice(1);
-      const b = node.args.slice(1);
+/**
+ * Converts nested text_replace to a text_multireplace provided the arguments are
+ * text literals with no overlap.
+ * @param singleCharInputsOnly Only applies the transform if the input args are single characters.
+ * This is used in Python. In the future it might can generalised to some general callback filter.
+ * @returns
+ */
+export function useMultireplace(singleCharInputsOnly = false): Plugin {
+  return {
+    name: "useMultireplace",
+    visit(node) {
       if (
-        a.every((x) => x.kind === "StringLiteral") &&
-        b.every((x) => x.kind === "StringLiteral")
+        isPolygolfOp(node, "text_replace", "text_multireplace") &&
+        isPolygolfOp(node.args[0], "text_replace", "text_multireplace")
       ) {
-        const aValues = a.map((x) => (x as StringLiteral).value);
-        const bValues = b.map((x) => (x as StringLiteral).value);
-        const aIn = [...aValues.filter((_, i) => i % 2 === 0).join()];
-        const aOut = new Set(aValues.filter((_, i) => i % 2 === 1).join());
-        const bIn = new Set(bValues.filter((_, i) => i % 2 === 0).join());
-        const bOut = new Set(bValues.filter((_, i) => i % 2 === 1).join());
+        const a = node.args[0].args.slice(1);
+        const b = node.args.slice(1);
         if (
-          !aIn.some((x) => bOut.has(x)) &&
-          ![...bIn].some((x) => aOut.has(x)) &&
-          !aIn.some((x) => bIn.has(x))
+          a.every((x) => x.kind === "StringLiteral") &&
+          b.every((x) => x.kind === "StringLiteral")
         ) {
-          return polygolfOp("text_multireplace", ...node.args[0].args, ...b);
+          const aValues = a.map((x) => (x as StringLiteral).value);
+          const bValues = b.map((x) => (x as StringLiteral).value);
+          const aIn = aValues.filter((_, i) => i % 2 === 0);
+          const aOut = aValues.filter((_, i) => i % 2 === 1);
+          const bIn = bValues.filter((_, i) => i % 2 === 0);
+          const bOut = bValues.filter((_, i) => i % 2 === 1);
+          const aInSet = new Set(aIn.join());
+          const aOutSet = new Set(aOut.join());
+          const bInSet = new Set(bIn.join());
+          const bOutSet = new Set(bOut.join());
+          if (
+            (!singleCharInputsOnly ||
+              [...aIn, ...bIn].every((x) => charLength(x) === 1)) &&
+            ![...aInSet].some((x) => bInSet.has(x)) &&
+            ![...bInSet].some((x) => aOutSet.has(x)) &&
+            ![...aInSet].some((x) => bOutSet.has(x))
+          ) {
+            return polygolfOp("text_multireplace", ...node.args[0].args, ...b);
+          }
         }
       }
-    }
-  },
-};
+    },
+  };
+}


### PR DESCRIPTION
- Implements the `text_replace` op in Lua, Nim, Python, Swift. In Lua, this is done by escaping the arguments and using the `gsub` function, I don't know if there's a better way.
- Implements a new backend-only `text_multireplace` op in Nim and Python.
- Adds a plugin converting a nested `text_replace`s to `text_multireplace`.