### PR TITLE
Use implicit output in golfscript

### DIFF
--- a/src/languages/golfscript/golfscript.test.md
+++ b/src/languages/golfscript/golfscript.test.md
@@ -10,7 +10,7 @@ print "b";
 ```
 
 ```golfscript nogolf
-1 puts 2 print"a"puts"b"print
+1 n 2"a"n"b"
 ```
 
 ## Ops emit
@@ -75,7 +75,7 @@ for $i 0 31 {
 ```
 
 ```golfscript bytes
-31,{:i;1 i+i i*+puts}%
+31,{:i;1 i+i i*+n}%
 ```
 
 ```polygolf
@@ -85,7 +85,7 @@ for $i 5 80 5 {
 ```
 
 ```golfscript nogolf
-80,5>5%{:i;i puts}%
+80,5>5%{:i;i n}%
 ```
 
 ```polygolf
@@ -95,7 +95,7 @@ for $i -5 31 {
 ```
 
 ```golfscript nogolf
-36,{5-:i;i puts}%
+36,{5-:i;i n}%
 ```
 
 ```polygolf
@@ -106,7 +106,7 @@ for $i $a ($a+6) {
 ```
 
 ```golfscript nogolf
--4:a;6,{a+:i;i puts}%
+-4:a;6,{a+:i;i n}%
 ```
 
 ## Argv
@@ -116,7 +116,7 @@ println (argv_get 5);
 ```
 
 ```golfscript nogolf
-:a;5 a=puts
+:a;5 a=n
 ```
 
 ```polygolf
@@ -126,5 +126,5 @@ for_argv $x 100 {
 ```
 
 ```golfscript nogolf
-:a;a{:x;x puts}%
+:a;a{:x;x n}%
 ```

--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -55,8 +55,8 @@ const golfscriptLanguage: Language = {
       ["argv", () => id("a", true)],
       ["true", () => id("1", true)],
       ["false", () => id("0", true)],
-      ["println", (x) => functionCall("puts", x)],
-      ["print", (x) => functionCall("print", x)],
+      ["println", (x) => functionCall("n", x)],
+      ["print", (x) => functionCall("", x)],
 
       [
         "text_get_byte_slice",

--- a/src/programs/code.golf-default.test.md
+++ b/src/programs/code.golf-default.test.md
@@ -22,7 +22,7 @@ for_argv $arg 1000 {
 _Golfscript_
 
 ```gs
-:a;"Hello, World!"puts 10,{:i;i puts}%a{:A;A puts}%
+:a;"Hello, World!"n 10,{:i;i n}%a{:A;A n}%
 ```
 
 _Lua_


### PR DESCRIPTION
Implicit output is strictly shorter in almost all cases, including all cases that can be generated by polygolf. I was a bit hesitant since this means the stack has to be kept clean of junk data but that shouldn't be too much of an issue.