### PR TITLE
Fix printing bug

### DIFF
--- a/src/languages/golfscript/golfscript.test.md
+++ b/src/languages/golfscript/golfscript.test.md
@@ -13,6 +13,16 @@ print "b";
 1 n 2"a"n"b"
 ```
 
+```polygolf
+$x:Int <- 1;
+print_int $x;
+print_int $x;
+```
+
+```golfscript nogolf
+1:x;x x
+```
+
 ## Ops emit
 
 ```polygolf

--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -64,7 +64,7 @@ const golfscriptLanguage: Language = {
       ["true", builtin("1")],
       ["false", builtin("0")],
       ["println", (x) => functionCall("n", x)],
-      ["print", (x) => functionCall("", x)],
+      ["print", (x) => x[0]],
 
       [
         "text_get_byte_slice",


### PR DESCRIPTION
Fixes
```polygolf
$x:Int <- 1;
print_int $x;
print_int $x;
```
compiling to golfscript as
```golfscript
1:x;xx
```
rather than
```golfscript
1:x;x x
```
Due to `print` adding an empty token