### PR TITLE
Add more int literals to Polygolf source

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Type expression is either
 
 ### Literals
 
-Integer literals are unbounded and written in base 10. String literals are JSON string literals.  
+Integer literals are unbounded and written in base 10. They permit scientific notation, so that `1e6` is the same as `1000000`. String literals are JSON string literals.  
 List literals are written as n-ary s-expressions:  
 `(list 1 2 3 4 5)`  
 Array and set literals are similar:  

--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ Type expression is either
 
 ### Literals
 
-Integer literals are unbounded and written in base 10. They permit scientific notation, so that `1e6` is the same as `1000000`. String literals are JSON string literals.  
+Integer literals are either
+
+- base 10 - no prefix, optionally using a scientific notation, so that `1e6` is the same as `1000000`,
+- base 2 - `0b` prefix,
+- base 16 - `0x` prefix.
+
+String literals are JSON string literals.  
 List literals are written as n-ary s-expressions:  
 `(list 1 2 3 4 5)`  
 Array and set literals are similar:  

--- a/src/frontend/grammar.ne
+++ b/src/frontend/grammar.ne
@@ -8,11 +8,11 @@ import {
   ifStatement,
   forRange,
   variants,
-  int,
   text,
   id as identifier
 } from "../IR";
 import {
+  int,
   sexpr,
   typeSexpr,
   integerType,
@@ -59,7 +59,7 @@ callee -> builtin {% id %}
   | opalias {% id %}
   | variable {% id %}
 
-integer -> %integer {% d => refSource(int(BigInt(d[0])), d[0]) %}
+integer -> %integer {% d => refSource(int(d[0]), d[0]) %}
 variable -> %variable {% d => refSource(userIdentifier(d[0]), d[0]) %}
 builtin -> (%builtin | "argv_get") {% d => refSource(identifier(d[0][0].value, true), d[0][0]) %}
 opalias -> (%opalias | "..") {% d => refSource(identifier(d[0][0].value, true), d[0][0]) %}

--- a/src/frontend/lexer.ts
+++ b/src/frontend/lexer.ts
@@ -1,7 +1,8 @@
 import moo from "moo";
 
 const tokenTable = {
-  integer: /0|-?[1-9]\d*(?:e[1-9]\d*)?/,
+  integer:
+    /0|-?[1-9]\d*(?:[eE][1-9]\d*)?|-?0x[1-9a-fA-F][\da-fA-F]*|-?0b1[01]*/,
   string: /"(?:\\.|[^"])*"/,
   variable: /\$\w+/,
   type: /[A-Z][a-z]*/,

--- a/src/frontend/lexer.ts
+++ b/src/frontend/lexer.ts
@@ -1,7 +1,7 @@
 import moo from "moo";
 
 const tokenTable = {
-  integer: /-?[0-9]+/,
+  integer: /0|-?[1-9]\d*(?:e[1-9]\d*)?/,
   string: /"(?:\\.|[^"])*"/,
   variable: /\$\w+/,
   type: /[A-Z][a-z]*/,

--- a/src/frontend/parse.test.ts
+++ b/src/frontend/parse.test.ts
@@ -41,6 +41,7 @@ function expectTypeParse(type: string, output: Type) {
 describe("Parse literals", () => {
   expectExprParse("single digit", "5", int(5n));
   expectExprParse("negative integer", "-123", int(-123n));
+  expectExprParse("scientific notation", "1e6", int(1000000n));
   expectExprParse("variable", "$y", id("y"));
   expectExprParse("string literal", '"abc"', text("abc"));
   expectExprParse("string with escapes", '"\\u0001\\r"', text("\u0001\r"));

--- a/src/frontend/parse.test.ts
+++ b/src/frontend/parse.test.ts
@@ -39,9 +39,11 @@ function expectTypeParse(type: string, output: Type) {
 }
 
 describe("Parse literals", () => {
-  expectExprParse("single digit", "5", int(5n));
-  expectExprParse("negative integer", "-123", int(-123n));
-  expectExprParse("scientific notation", "1e6", int(1000000n));
+  expectExprParse("single digit", "5", int(5));
+  expectExprParse("negative integer", "-123", int(-123));
+  expectExprParse("scientific notation", "1e6", int(1000000));
+  expectExprParse("binary literal", "-0b100110", int(-0b100110));
+  expectExprParse("hexadecimal literal", "-0xabcdef", int(-0xabcdef));
   expectExprParse("variable", "$y", id("y"));
   expectExprParse("string literal", '"abc"', text("abc"));
   expectExprParse("string with escapes", '"\\u0001\\r"', text("\u0001\r"));

--- a/src/frontend/parse.ts
+++ b/src/frontend/parse.ts
@@ -17,7 +17,7 @@ import {
   setType,
   integerType as intType,
   IntegerLiteral,
-  int,
+  int as integer,
   assignment,
   OpCode,
   whileLoop,
@@ -168,8 +168,8 @@ export function sexpr(callee: Identifier, args: readonly Expr[]): Expr {
     case "for": {
       expectArity(2, 5);
       let variable: Expr = id("_");
-      let start: Expr = int(0n);
-      let step: Expr = int(1n);
+      let start: Expr = integer(0n);
+      let step: Expr = integer(1n);
       let end, body: Expr;
       if (args.length === 5) {
         [variable, start, end, step, body] = args;
@@ -327,7 +327,7 @@ export function sexpr(callee: Identifier, args: readonly Expr[]): Expr {
           [start, end, step, body] = args;
         } else {
           [start, end, body] = args;
-          step = int(1n);
+          step = integer(1n);
         }
         return forRange(undefined, start, end, step, body);
       }
@@ -351,6 +351,11 @@ export function sexpr(callee: Identifier, args: readonly Expr[]): Expr {
     `Syntax error. Unrecognized builtin: ${opCode}`,
     callee.source
   );
+}
+
+export function int(x: Token) {
+  const parts = x.toString().split("e");
+  return integer(BigInt(parts[0]) * 10n ** BigInt(parts[1] ?? "0"));
 }
 
 export const canonicalOpTable: Record<string, OpCode> = {

--- a/src/frontend/parse.ts
+++ b/src/frontend/parse.ts
@@ -353,9 +353,15 @@ export function sexpr(callee: Identifier, args: readonly Expr[]): Expr {
   );
 }
 
+function intValue(x: string): bigint {
+  if (x[0] === "-") return -intValue(x.substring(1));
+  if (x[0] === "0") return BigInt(x);
+  const parts = x.toString().split(/[eE]/);
+  return BigInt(parts[0]) * 10n ** BigInt(parts[1] ?? "0");
+}
+
 export function int(x: Token) {
-  const parts = x.toString().split("e");
-  return integer(BigInt(parts[0]) * 10n ** BigInt(parts[1] ?? "0"));
+  return integer(intValue(x.text));
 }
 
 export const canonicalOpTable: Record<string, OpCode> = {


### PR DESCRIPTION
This is a syntactic sugar improvement that allows `1e6` instead of `1000000` in Polygolf source.
Edit: This adds binary and hexadecimal litarals too.